### PR TITLE
fix the ignite zip download url

### DIFF
--- a/apache-ignite/install-ignite-v01.sh
+++ b/apache-ignite/install-ignite-v01.sh
@@ -54,7 +54,7 @@ export HADOOP_HDFS_HOME="/usr/hdp/current/hadoop-hdfs-client";
 export HADOOP_MAPRED_HOME="/usr/hdp/current/hadoop-mapreduce-client";
 
 IGNITE_BINARY="apache-ignite-hadoop-1.7.0-bin";
-IGNITE_BINARY_URI="https://www.apache.org/dist/ignite/1.7.0/$IGNITE_BINARY.zip";
+IGNITE_BINARY_URI="https://archive.apache.org/dist/ignite/1.7.0/$IGNITE_BINARY.zip";
 IGNITE_TMPFOLDER=/tmp/ignite
 export IGNITE_HOME_DIR="/hadoop/ignite";
 export IGNITE_HOME="$IGNITE_HOME_DIR/$IGNITE_BINARY";


### PR DESCRIPTION
The old url https://www.apache.org/dist/ignite/1.7.0/ does not work.
Update it to https://archive.apache.org/dist/ignite/1.7.0/